### PR TITLE
nerver use object shorthand in ES5

### DIFF
--- a/rules/legacy.js
+++ b/rules/legacy.js
@@ -12,5 +12,7 @@ module.exports = {
     'no-bitwise': 0,
     // disallow use of unary operators, ++ and --
     'no-plusplus': 0,
+    // disallow object short hand
+    'object-shorthand': [2, 'never'],
   },
 };


### PR DESCRIPTION
bad browser support
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer

但是我看 base 裡面是 extend airbnb 的 legacy XD
不知道要不要改