### PR TITLE
Remove settings on react.js rules

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -35,16 +35,4 @@ module.exports = {
     // Proposal - https://github.com/Yoctol/eslint-config-yoctol/issues/21
     'react/jsx-filename-extension': ['error', { extensions: ['.js'] }],
   },
-
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: ['.js', '.jsx', '.json'],
-      },
-    },
-    react: {
-      pragma: 'React',
-      version: '15.0',
-    },
-  },
 };


### PR DESCRIPTION
We should not overwrite the `settings` option on `react.js` config file.